### PR TITLE
Notes on implementation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ And the application will safely run in the main thread.
 
 In the case where the main thread /is/ the evaluating thread, no additional threads are started, and the runner used will simply directly run tasks.
 
+## Implementation Support
+
+This library is known to work with sbcl, ccl, ecl, clasp & cmucl.
+
+We could not provide support to the following due to the not having a way to query the main-thread: allegro, abcl, corman & scl.
+
+And lastly mkcl & lispworks, whilst having the concept of a main-thread, do not support trivial-main-thread's other dependencies.
+
+Mileage on other CL implementations will vary.
+
 ## Also See
 
 * [Simple-tasks](https://shinmera.github.io/simple-tasks) For remote task running.


### PR DESCRIPTION
I have done a good pass through the implementations slime supports (which is as good a metric as any for viability) and found some details that I feel were worth documenting here.

lispworks failed because of asdf issues. ManKai failed because strack trace wasn't supported (but you can query the main thread reliably)

Allegro was too expensive to even try, but their docs didn't look hopeful.